### PR TITLE
fix error replacing '.' by file separator on windows

### DIFF
--- a/lagom-descriptor-generator/src/it/scala/com/lightbend/lagom/spec/JavaCustomModelGeneratorSpec.scala
+++ b/lagom-descriptor-generator/src/it/scala/com/lightbend/lagom/spec/JavaCustomModelGeneratorSpec.scala
@@ -1,6 +1,7 @@
 package com.lightbend.lagom.spec
 
-import org.scalatest.{ FlatSpec, Matchers }
+import org.apache.commons.lang3.StringUtils
+import org.scalatest.{FlatSpec, Matchers}
 
 class JavaCustomModelGeneratorSpec extends FlatSpec with Matchers {
 
@@ -15,8 +16,8 @@ class JavaCustomModelGeneratorSpec extends FlatSpec with Matchers {
     val inputStream = resource(s"$folder/swagger.json")
 
     val models = LagomGenerators.openApiV2ToLagomJava(inputStream, packageName, "pet").models
-    val generated: String = models("Pet").fileContents
-    val expected: String = loadContents(s"$folder/Pet.java.txt")
+    val generated: String = StringUtils.normalizeSpace(models("Pet").fileContents)
+    val expected: String = StringUtils.normalizeSpace(loadContents(s"$folder/Pet.java.txt"))
     expected should be(generated)
 
   }
@@ -27,8 +28,8 @@ class JavaCustomModelGeneratorSpec extends FlatSpec with Matchers {
     val inputStream = resource(s"$folder/swagger.json")
 
     val models = LagomGenerators.openApiV2ToLagomJava(inputStream, packageName, "pet").models
-    val generated: String = models("StatusEnum").fileContents
-    val expected: String = loadContents(s"$folder/StatusEnum.java.txt")
+    val generated: String = StringUtils.normalizeSpace(models("StatusEnum").fileContents)
+    val expected: String = StringUtils.normalizeSpace(loadContents(s"$folder/StatusEnum.java.txt"))
     expected should be(generated)
 
   }

--- a/lagom-descriptor-generator/src/it/scala/com/lightbend/lagom/spec/LagomJavaDescriptorSpec.scala
+++ b/lagom-descriptor-generator/src/it/scala/com/lightbend/lagom/spec/LagomJavaDescriptorSpec.scala
@@ -1,6 +1,8 @@
 package com.lightbend.lagom.spec
 
-import org.scalatest.{ FlatSpec, Matchers }
+import com.lightbend.lagom.spec.LagomGeneratorTypes.GeneratedCode
+import org.apache.commons.lang3.StringUtils
+import org.scalatest.{FlatSpec, Matchers}
 
 class LagomJavaDescriptorSpec extends FlatSpec with Matchers {
 
@@ -14,8 +16,9 @@ class LagomJavaDescriptorSpec extends FlatSpec with Matchers {
     val packageName = "com.example.pet.api"
     val inputStream = resource(s"$folder/swagger.json")
 
-    val generatedCode: String = LagomGenerators.openApiV2ToLagomJava(inputStream, packageName, "pet").descriptor.fileContents
-    val expected: String = loadContents(s"$folder/sample-java-descriptor.txt")
+    val descriptor = LagomGenerators.openApiV2ToLagomJava(inputStream, packageName, "pet").descriptor
+    val generatedCode: String = StringUtils.normalizeSpace(descriptor.fileContents)
+    val expected: String = StringUtils.normalizeSpace(loadContents(s"$folder/sample-java-descriptor.txt"))
     expected should be(generatedCode)
 
   }

--- a/lagom-descriptor-generator/src/it/scala/com/lightbend/lagom/spec/LagomScalaDescriptorSpec.scala
+++ b/lagom-descriptor-generator/src/it/scala/com/lightbend/lagom/spec/LagomScalaDescriptorSpec.scala
@@ -1,6 +1,7 @@
 package com.lightbend.lagom.spec
 
-import org.scalatest.{ FlatSpec, Matchers }
+import org.apache.commons.lang3.StringUtils
+import org.scalatest.{FlatSpec, Matchers}
 
 class LagomScalaDescriptorSpec extends FlatSpec with Matchers {
 
@@ -14,8 +15,9 @@ class LagomScalaDescriptorSpec extends FlatSpec with Matchers {
     val packageName = "com.example.pet.api"
     val inputStream = resource(s"$folder/swagger.json")
 
-    val generatedCode: String = LagomGenerators.openApiV2ToLagomScala(inputStream, packageName, "pet").descriptor.fileContents
-    val expected: String = loadContents(s"$folder/sample-scala-descriptor.txt")
+    val descriptor = LagomGenerators.openApiV2ToLagomScala(inputStream, packageName, "pet").descriptor
+    val generatedCode: String = StringUtils.normalizeSpace(descriptor.fileContents)
+    val expected: String = StringUtils.normalizeSpace(loadContents(s"$folder/sample-scala-descriptor.txt"))
     expected should be(generatedCode)
 
   }

--- a/lagom-renderers/javadsl/src/main/scala/com/lightbend/lagom/spec/render/LagomJavaRender.scala
+++ b/lagom-renderers/javadsl/src/main/scala/com/lightbend/lagom/spec/render/LagomJavaRender.scala
@@ -4,6 +4,7 @@
 package com.lightbend.lagom.spec.render
 
 import java.io.File
+import java.util.regex.Matcher
 
 import com.lightbend.lagom.spec.LagomGeneratorTypes
 import com.lightbend.lagom.spec.LagomGeneratorTypes.{ GeneratedCode, Output }
@@ -30,6 +31,6 @@ object LagomJavaRender {
   }
 
   private def getPath(service: Service, className: String): String = {
-    s"${service.`package`.replaceAll("\\.", File.separator)}${File.separator}${className}.java"
+    s"${service.`package`.replaceAll("\\.", Matcher.quoteReplacement(File.separator))}${File.separator}${className}.java"
   }
 }

--- a/lagom-renderers/scaladsl/src/main/scala/com/lightbend/lagom/spec/render/LagomScalaRender.scala
+++ b/lagom-renderers/scaladsl/src/main/scala/com/lightbend/lagom/spec/render/LagomScalaRender.scala
@@ -4,6 +4,7 @@
 package com.lightbend.lagom.spec.render
 
 import java.io.File
+import java.util.regex.Matcher
 
 import com.lightbend.lagom.spec.LagomGeneratorTypes
 import com.lightbend.lagom.spec.LagomGeneratorTypes.{ GeneratedCode, Output }
@@ -31,6 +32,6 @@ object LagomScalaRender {
   }
 
   private def getPath(service: Service, className: String): String = {
-    s"${service.`package`.replaceAll("\\.", File.separator)}${File.separator}${className}.scala"
+    s"${service.`package`.replaceAll("\\.", Matcher.quoteReplacement(File.separator))}${File.separator}${className}.scala"
   }
 }


### PR DESCRIPTION
When executing integration tests on windows gives the following error:


`[info] - should generate a Lagom Scala Descriptor given an OpenAPI v2 file *** FAILED ***
[info]   java.lang.IllegalArgumentException: character to be escaped is missing
[info]   at java.util.regex.Matcher.appendReplacement(Matcher.java:809)
[info]   at java.util.regex.Matcher.replaceAll(Matcher.java:955)
[info]   at java.lang.String.replaceAll(String.java:2223)
[info]   at com.lightbend.lagom.spec.render.LagomScalaRender$.com$lightbend$lagom$spec$render$LagomScalaRender$$getPath(LagomScalaRender.scala:34)
[info]   at com.lightbend.lagom.spec.render.LagomScalaRender$$anonfun$1.apply(LagomScalaRender.scala:20)
[info]   at com.lightbend.lagom.spec.render.LagomScalaRender$$anonfun$1.apply(LagomScalaRender.scala:19)
[info]   at scala.Function1$$anonfun$andThen$1.apply(Function1.scala:55)
[info]   at com.lightbend.lagom.spec.LagomGenerator$class.generate(LagomGenerator.scala:34)
[info]   at com.lightbend.lagom.spec.LagomGenerators$$anon$2.generate(LagomGenerators.scala:26)
[info]   at com.lightbend.lagom.spec.LagomGenerators$.openApiV2ToLagomScala(LagomGenerators.scala:26)`

So the file separator \'\\' have to be escaped when replacing '.'

Also, the tests have been changed due to line separator differences beetween windows and unix

