### PR TITLE
add support an optional parameter in a query

### DIFF
--- a/spec-parsers/openapi/src/main/scala/com/lightbend/lagom/spec/parser/OpenApiV2Parser.scala
+++ b/spec-parsers/openapi/src/main/scala/com/lightbend/lagom/spec/parser/OpenApiV2Parser.scala
@@ -180,7 +180,8 @@ class OpenApiV2Parser(packageName: String, serviceName: String) extends SpecPars
         }
 
     val arguments = (pathParams(operation) ++ queryParams(operation)).map { param =>
-      CallArgument(param.getName, paramTypeDiscovery(param.getName, param.asInstanceOf[AbstractSerializableParameter[_]]))
+      val arg = CallArgument(param.getName, paramTypeDiscovery(param.getName, param.asInstanceOf[AbstractSerializableParameter[_]]))
+      if (param.getRequired) arg else arg.copy(`type` = LOptional(arg.`type`))
     }
 
     // TODO: normalize operationId name to a valid java/scala method name.


### PR DESCRIPTION
Hello!

We want to use optional parameters in an HTTP request, as it described [here](https://apigee.com/about/blog/technology/restful-api-design-can-your-api-give-developers-just-information-they-need) for pagination. "offset" and "limit" must be optional parameters.

This pull-request adds processing support for not required query parameter (i.e. /items?id=###).

Swagger:
````swagger
paths:
  # dogs
  /dogs:
    get:
      operationId: getDogs
      produces:
        - application/json
      parameters:
        - name: limit
          in: query
          required: false
          type: integer
          format: int32
        - name: offset
          in: query
          required: false
          type: integer
          format: int32
      responses:
        200:
          schema:
            $ref: "#/definitions/Dogs"

  /just_test:
    get:
      operationId: justTest
      produces:
        - application/json
      parameters:
        - name: default
          in: query
          type: integer
          format: int32
        - name: required
          in: query
          required: true
          type: integer
          format: int32
        - name: optional
          in: query
          required: false
          type: integer
          format: int32
      responses:
        200:
          schema:
            $ref: "#/definitions/Dogs"
````
Old Scala code:
````scala
trait DogsApi extends Service {

    def getDogs(limit: Int, offset: Int): ServiceCall[akka.NotUsed, Dogs]
    def justTest(default: Int, required: Int, optional: Int): ServiceCall[akka.NotUsed, Dogs]

    final override def descriptor: Descriptor = {
        named("dogs").withCalls(
                restCall(Method.GET, "/api/v1.0/dogs?limit&offset", getDogs _),
                restCall(Method.GET, "/api/v1.0/just_test?default&optional&required", justTest _)
        ).withAutoAcl(true)
    }
}
````
New Scala code:
````scala
trait DogsApi extends Service {

    def getDogs(limit: Option[Int], offset: Option[Int]): ServiceCall[akka.NotUsed, Dogs]
    def justTest(default: Option[Int], required: Int, optional: Option[Int]): ServiceCall[akka.NotUsed, Dogs]

    final override def descriptor: Descriptor = {
        named("dogs").withCalls(
                restCall(Method.GET, "/api/v1.0/dogs?limit&offset", getDogs _),
                restCall(Method.GET, "/api/v1.0/just_test?default&optional&required", justTest _)
        ).withAutoAcl(true)
    }
}
````
[Test project.](https://github.com/lagom/sbt-lagom-descriptor-generator/files/1253690/hello.tar.gz)
